### PR TITLE
Add categories

### DIFF
--- a/src/main/java/com/ciandt/techgallery/persistence/model/Technology.java
+++ b/src/main/java/com/ciandt/techgallery/persistence/model/Technology.java
@@ -44,6 +44,7 @@ public class Technology extends BaseEntity<String> {
   public static final String LAST_ACTIVITY = "lastActivity";
   public static final String UPDATE_USER = "updateUser";
   public static final String ACTIVE = "active";
+  public static final String CATEGORY = "category";
 
   /*
    * Attributes --------------------------------------------
@@ -111,6 +112,9 @@ public class Technology extends BaseEntity<String> {
 
   @Ignore
   private String imageContent;
+
+  @Index
+  private String category;
 
   /*
    * Getter's and Setter's --------------------------------------------
@@ -287,6 +291,14 @@ public class Technology extends BaseEntity<String> {
 
   public void setIdBoard(String idBoard) {
     this.idBoard = idBoard;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public void setCategory(String category) {
+    this.category = category;
   }
 
   /*

--- a/src/main/java/com/ciandt/techgallery/service/TechnologyService.java
+++ b/src/main/java/com/ciandt/techgallery/service/TechnologyService.java
@@ -13,6 +13,7 @@ import com.ciandt.techgallery.service.model.TechnologyFilter;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Services for Technologies.
@@ -102,7 +103,7 @@ public interface TechnologyService {
   /**
    * Service to delete a technology.
    *
-   * @param technology entity id.
+   * @param technologyId entity id.
    * @return Technology or message error.
    * @throws InternalServerErrorException .
    * @throws BadRequestException .
@@ -110,4 +111,6 @@ public interface TechnologyService {
   Technology deleteTechnology(final String technologyId, User user)
       throws InternalServerErrorException, BadRequestException, NotFoundException,
       OAuthRequestException;
+
+  Map<String, String> getCategories();
 }

--- a/src/main/java/com/ciandt/techgallery/service/endpoint/TechnologyEndpoint.java
+++ b/src/main/java/com/ciandt/techgallery/service/endpoint/TechnologyEndpoint.java
@@ -26,6 +26,7 @@ import com.ciandt.techgallery.transaction.ServiceFactory;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -163,4 +164,14 @@ public class TechnologyEndpoint {
     return service.deleteTechnology(technologyId, user);
   }
 
+  /**
+   * Endpoint for getting Technology categories.
+   *
+   * @return all categories
+   * @throws BadRequestException when some request parameter is wrong missing
+   */
+  @ApiMethod(name = "getTechnologyCategories", path = "technology/categories", httpMethod = "get")
+  public Map<String, String> getTechnologyCategories() throws BadRequestException{
+    return service.getCategories();
+  }
 }

--- a/src/main/java/com/ciandt/techgallery/service/enums/TechnologyCategoryEnum.java
+++ b/src/main/java/com/ciandt/techgallery/service/enums/TechnologyCategoryEnum.java
@@ -1,0 +1,26 @@
+package com.ciandt.techgallery.service.enums;
+
+public enum TechnologyCategoryEnum {
+
+    TECHNIQUE("technique", "Technique"),
+    TOOL("tool", "Tools"),
+    LANGUAGE("language", "Language"),
+    FRAMEWORK("framework", "Framework"),
+    PLATFORM("platform", "Platform");
+
+    private String id;
+    private String title;
+
+    TechnologyCategoryEnum(String id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/com/ciandt/techgallery/service/enums/ValidationMessageEnums.java
+++ b/src/main/java/com/ciandt/techgallery/service/enums/ValidationMessageEnums.java
@@ -21,6 +21,8 @@ public enum ValidationMessageEnums {
   TECHNOLOGY_NAME_ALREADY_USED("Technology already exists with this name."),
   TECHNOLOGY_NOT_EXIST("Technology doesn't exist."),
   TECHNOLOGY_NAME_CANNOT_CHANGE("Technology's name cannot be changed."),
+  TECHNOLOGY_CATEGORY_BLANK("Technology's category cannot be null or blank."),
+  TECHNOLOGY_CATEGORY_INVALID("Technology's category must be valid. Valid categories: %s. %s given."),
   // Message for users
   USER_CANNOT_BLANK("User or user's id cannot be null or blank."),
   USER_NOT_EXIST("User doesn't exist."),

--- a/src/main/java/com/ciandt/techgallery/service/model/TechnologyTO.java
+++ b/src/main/java/com/ciandt/techgallery/service/model/TechnologyTO.java
@@ -48,6 +48,8 @@ public class TechnologyTO implements Response {
   private String idBoard;
   /** technology smart canvas board id */
   private String boardUrlPrefix;
+  /** technology category */
+  private String category;
 
   private Date lastActivity;
 
@@ -203,5 +205,13 @@ public class TechnologyTO implements Response {
 
   public void setBoardUrlPrefix(String boardUrlPrefix) {
     this.boardUrlPrefix = boardUrlPrefix;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public void setCategory(String category) {
+    this.category = category;
   }
 }

--- a/src/main/java/com/ciandt/techgallery/service/transformer/TechnologyTransformer.java
+++ b/src/main/java/com/ciandt/techgallery/service/transformer/TechnologyTransformer.java
@@ -26,6 +26,7 @@ public class TechnologyTransformer implements Transformer<Technology, Technology
     product.setLastActivity(baseObject.getLastActivity());
     product.setImageContent(baseObject.getImageContent());
     product.setIdBoard(baseObject.getIdBoard());
+    product.setCategory(baseObject.getCategory());
 
     if(baseObject.getProject() != null) {
       ProjectTransformer projectTransformer = new ProjectTransformer();
@@ -57,6 +58,7 @@ public class TechnologyTransformer implements Transformer<Technology, Technology
       product.setImageContent(baseObject.getImageContent());
       product.setIdBoard(baseObject.getIdBoard());
       product.setBoardUrlPrefix(System.getProperty("board.url.prefix"));
+      product.setCategory(baseObject.getCategory());
 
       if(baseObject.getProject() != null) {
         ProjectTransformer projectTransformer = new ProjectTransformer();

--- a/src/main/resources/i18n/Tech_Gallery_en_US.properties
+++ b/src/main/resources/i18n/Tech_Gallery_en_US.properties
@@ -60,3 +60,5 @@ Link\ doesn't\ exist. = Link doesn't exist.
 Link\ or\ link's\ id\ cannot\ be\ null\ or\ blank. = Link or link's id cannot be null or blank.
 This\ link\ doesn't\ belong\ to\ this\ user. = This link doesn't belong to this user.
 This\ link\ is\ not\ valid. = This link is not valid.
+Technology's\ category\ cannot\ be\ null\ or\ blank.=Technology's category cannot be null or blank.
+Technology's\ category\ must\ be\ valid.\ Valid\ categories\:\ %s.\ %s\ given.=Technology's category must be valid. Valid categories: %s. %s given.

--- a/src/main/webapp/app/modules/technology/controllers/TechnologyAddController.js
+++ b/src/main/webapp/app/modules/technology/controllers/TechnologyAddController.js
@@ -37,7 +37,7 @@ module.exports = function ($rootScope, AppService, TechnologyService, ProjectSer
     context.project = {id: 0, name: 'Não'};
   }
 
-  $scope.initSelect = function () {
+  $scope.initProjectsSelect = function () {
     ProjectService.getProjects().then(function (data) {
       if (!data) {
         data = [];
@@ -47,13 +47,23 @@ module.exports = function ($rootScope, AppService, TechnologyService, ProjectSer
     });
   };
 
+  $scope.initCategoriesSelect = function () {
+    TechnologyService.getCategories().then(function (data) {
+      context.dropDownCategories = [];
+      for (var key in data) {
+        context.dropDownCategories.push({id: key, name: data[key]});
+      }
+    });
+  };
+
+
   this.addOrUpdateTechnology = function (form) {
     if (context.project.id === 0) {
       context.project = undefined;
     }
 
     var isEdit = (context.id !== undefined);
-    if (context.name != null && context.description != null && context.shortDescription != null) {
+    if (context.name != null && context.description != null && context.shortDescription != null && context.category != null) {
       TechnologyService.addOrUpdate(context).then(function (data) {
         if (data.hasOwnProperty('error')) {
           AppService.setAlert(data.error.message, 'error');
@@ -84,6 +94,7 @@ module.exports = function ($rootScope, AppService, TechnologyService, ProjectSer
     context.description = '';
     context.shortDescription = '';
     context.webSite = '';
+    context.category = '';
     document.getElementById('technology-name').value = null;
     document.getElementById('technology-project').value = null;
     document.getElementById('list').innerHTML = ['<img src="/assets/images/no_image.png" title="Insira uma imagem" />'].join('');
@@ -98,6 +109,7 @@ module.exports = function ($rootScope, AppService, TechnologyService, ProjectSer
     context.webSite = technology.website;
     context.image = technology.image;
     context.project = (technology.project ? technology.project : {id: 0, name: 'Não'});
+    context.category = technology.category;
     if (context.image) {
       document.getElementById('list').innerHTML = ['<img src="', context.image, '" title="', context.name, '" />'].join('');
     }

--- a/src/main/webapp/app/modules/technology/services/TechnologyService.js
+++ b/src/main/webapp/app/modules/technology/services/TechnologyService.js
@@ -87,7 +87,8 @@ module.exports = function($q, $timeout, $rootScope) {
         description : context.description,
         website : context.webSite,
         image : context.image,
-        project : context.project
+        project : context.project,
+        category : context.category.id
       };
       return req;
     }else{
@@ -101,7 +102,8 @@ module.exports = function($q, $timeout, $rootScope) {
         description : context.description,
         website : context.webSite,
         imageContent : context.image,
-        project : context.project
+        project : context.project,
+        category : context.category.id
       };
       return req;
     }
@@ -464,6 +466,19 @@ module.exports = function($q, $timeout, $rootScope) {
     req.technology = idTech;
     gapi.client.rest.addEndorsementPlusOne(req).execute(function(data){
       deferred.resolve(data);
+    });
+    return deferred.promise;
+  };
+
+  /**
+   * Retrieve list of categories
+   * @return {Promise} The gapi response
+   */
+  this.getCategories = function () {
+    var deferred = $q.defer();
+    gapi.client.rest.getTechnologyCategories().execute(function (data) {
+      context.foundItems = data.result;
+      deferred.resolve(context.foundItems);
     });
     return deferred.promise;
   };

--- a/src/main/webapp/app/modules/technology/services/TechnologyService.js
+++ b/src/main/webapp/app/modules/technology/services/TechnologyService.js
@@ -88,7 +88,7 @@ module.exports = function($q, $timeout, $rootScope) {
         website : context.webSite,
         image : context.image,
         project : context.project,
-        category : context.category.id
+        category : context.category
       };
       return req;
     }else{
@@ -103,7 +103,7 @@ module.exports = function($q, $timeout, $rootScope) {
         website : context.webSite,
         imageContent : context.image,
         project : context.project,
-        category : context.category.id
+        category : context.category
       };
       return req;
     }

--- a/src/main/webapp/app/modules/technology/views/technology-add.html
+++ b/src/main/webapp/app/modules/technology/views/technology-add.html
@@ -51,11 +51,26 @@
                   </div>
                 </div>
                 <!--End Technology Name-->
+
+                <!--Category Selector-->
+                <div class="form-group col-md-3"
+                      ng-class="{'has-error': (addTechnologyForm.category.$invalid && addTechnologyForm.category.$touched) || (addTechnologyForm.$submitted && addTechnologyForm.category.$invalid)}">
+                  <label for="technology-category">Categoria</label>
+                  <select class="form-control ng-pristine ng-valid ng-empty ng-touched" ng-model="technology.category"
+                          id="technology-category" name="category" required="" ng-init="initCategoriesSelect()"
+                          ng-options="category.name for category in technology.dropDownCategories track by category.id">
+                  </select>
+                  <div ng-show="addTechnologyForm.$submitted || addTechnologyForm.category.$touched">
+                    <span ng-show="addTechnologyForm.category.$error.required" class="help-block">O campo Categoria é obrigatório</span>
+                  </div>
+                </div>
+                <!--End Category Selector-->
+
                 <!--Projects Selector-->
-                <div class="form-group col-md-7">
+                <div class="form-group col-md-4">
                   <label for="technology-project">Exibir apenas para projeto específico</label>
                   <select class="form-control ng-pristine ng-valid ng-empty ng-touched" ng-model="technology.project"
-                          id="technology-project" ng-init="initSelect()"
+                          id="technology-project" ng-init="initProjectsSelect()"
                           ng-options="project.name for project in technology.dropDownProjects track by project.id">
                   </select>
                   <!--Project Modal-->

--- a/src/main/webapp/app/modules/technology/views/technology-add.html
+++ b/src/main/webapp/app/modules/technology/views/technology-add.html
@@ -58,7 +58,7 @@
                   <label for="technology-category">Categoria</label>
                   <select class="form-control ng-pristine ng-valid ng-empty ng-touched" ng-model="technology.category"
                           id="technology-category" name="category" required="" ng-init="initCategoriesSelect()"
-                          ng-options="category.name for category in technology.dropDownCategories track by category.id">
+                          ng-options="category.id as category.name for category in technology.dropDownCategories">
                   </select>
                   <div ng-show="addTechnologyForm.$submitted || addTechnologyForm.category.$touched">
                     <span ng-show="addTechnologyForm.category.$error.required" class="help-block">O campo Categoria é obrigatório</span>

--- a/src/main/webapp/app/modules/user/views/user.html
+++ b/src/main/webapp/app/modules/user/views/user.html
@@ -41,7 +41,7 @@
       <!--Projects Selector-->
       <div class="pull-right form-group col-md-5">
         <label for="technology-project">Quer visualizar as tecnologias específicas de um projeto?</label>
-        <select class="form-control ng-pristine ng-valid ng-empty ng-touched" ng-model="user.profile.owner.project" ng-init="initSelect()" ng-change="onProjectSelection()"
+        <select class="form-control ng-pristine ng-valid ng-empty ng-touched" ng-model="user.profile.owner.project" ng-init="initProjectsSelect()" ng-change="onProjectSelection()"
                 ng-options="project.name for project in user.dropDownProjects track by project.id" id="technology-project">
         </select>
       </div>

--- a/src/test/java/com/ciandt/techgallery/service/TechnologyServiceTest.java
+++ b/src/test/java/com/ciandt/techgallery/service/TechnologyServiceTest.java
@@ -1,6 +1,7 @@
 package com.ciandt.techgallery.service;
 
 import com.ciandt.techgallery.persistence.model.Technology;
+import com.ciandt.techgallery.service.enums.TechnologyCategoryEnum;
 import com.ciandt.techgallery.service.impl.TechnologyServiceImpl;
 import com.google.api.server.spi.response.BadRequestException;
 import com.google.appengine.api.users.User;
@@ -27,6 +28,7 @@ public class TechnologyServiceTest {
 		technology.setName("Angular JS");
 		technology.setDescription("Framework javascript");
 		technology.setShortDescription("Framework javascript");
+		technology.setCategory(TechnologyCategoryEnum.FRAMEWORK.getId());
 
 		service.addOrUpdateTechnology(technology, currentUser);
 	}
@@ -37,6 +39,31 @@ public class TechnologyServiceTest {
 		technology.setId(technology.convertNameToId("Angular JS"));
 		technology.setDescription("Framework javascript");
 		technology.setShortDescription("Framework javascript");
+		technology.setCategory(TechnologyCategoryEnum.FRAMEWORK.getId());
+
+		service.addOrUpdateTechnology(technology, currentUser);
+	}
+
+	@Test (expected = BadRequestException.class)
+	public void shouldThrowBadRequestWhenInsertWithNoCategory() throws Exception {
+		Technology technology = new Technology();
+		technology.setId(technology.convertNameToId("Angular JS"));
+		technology.setName("Angular JS");
+		technology.setDescription("Framework javascript");
+		technology.setShortDescription("Framework javascript");
+
+		service.addOrUpdateTechnology(technology, currentUser);
+	}
+
+
+	@Test (expected = BadRequestException.class)
+	public void shouldThrowBadRequestWhenInsertWithInvalidCategory() throws Exception {
+		Technology technology = new Technology();
+		technology.setId(technology.convertNameToId("Angular JS"));
+		technology.setName("Angular JS");
+		technology.setDescription("Framework javascript");
+		technology.setShortDescription("Framework javascript");
+		technology.setCategory("invalid-CATEGORY");
 
 		service.addOrUpdateTechnology(technology, currentUser);
 	}

--- a/src/test/java/service/technology/ShareTechnologyTest.java
+++ b/src/test/java/service/technology/ShareTechnologyTest.java
@@ -1,8 +1,13 @@
 package service.technology;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 import com.ciandt.techgallery.persistence.model.Technology;
 import com.ciandt.techgallery.service.TechnologyService;
+import com.ciandt.techgallery.service.enums.TechnologyCategoryEnum;
 import com.ciandt.techgallery.service.impl.TechnologyServiceImpl;
+import com.google.api.server.spi.response.BadRequestException;
 import com.google.appengine.api.users.User;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.api.utils.SystemProperty;
@@ -57,6 +62,7 @@ public class ShareTechnologyTest {
         technology.setName("Angular JS");
         technology.setDescription("Framework javascript");
         technology.setShortDescription("Framework javascript");
+        technology.setCategory(TechnologyCategoryEnum.FRAMEWORK.getId());
 
         Technology founded = service.addOrUpdateTechnology(technology, currentUser);
 
@@ -83,6 +89,7 @@ public class ShareTechnologyTest {
         technology.setName("Angular JS");
         technology.setDescription("Framework javascript");
         technology.setShortDescription("Framework javascript");
+        technology.setCategory(TechnologyCategoryEnum.FRAMEWORK.getId());
 
         // add imagem content - TODO: storage bucket not work using unit test
         // technology.setImageContent("sample base64 imagem data");


### PR DESCRIPTION
Some weeks ago people were trying to analyse our data and we figure out that we don't have categories.

TW Radar's has 4 categories: Techniques, Tools, Platforms, Languages & Frameworks.

Since we already use some categories (Technique, Tools, Language, Framework) at the knowledge map spreadsheet, I kept them and I also added the last one (Platform).
So, our categories are Technique, Tools, Language, Framework, Platform

- The system will continue to work with current data. 
- The category will be required when editing a technology or when adding a new one.

We can think about a migration later, if needed.