### PR TITLE
Move tasks arguments to a Kind

### DIFF
--- a/src/main/java/com/ciandt/techgallery/persistence/model/EmailNotification.java
+++ b/src/main/java/com/ciandt/techgallery/persistence/model/EmailNotification.java
@@ -2,6 +2,7 @@ package com.ciandt.techgallery.persistence.model;
 
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.Unindex;
 
 import java.util.Date;
@@ -12,16 +13,28 @@ public class EmailNotification extends BaseEntity<Long> {
 
   @Id
   private Long id;
+
   @Unindex
   private List<String> recipients;
+
   @Unindex
-  private String rule;
+  private String subject;
+
+  @Unindex
+  private String body;
+
   @Unindex
   private String reason;
+
   @Unindex
   private String emailStatus;
-  @Unindex
+
+  @Index
+  private Date timestamp;
+
+  @Index
   private Date timestampSend;
+
 
   public Long getId() {
     return id;
@@ -39,12 +52,20 @@ public class EmailNotification extends BaseEntity<Long> {
     this.recipients = recipients;
   }
 
-  public String getRule() {
-    return rule;
+  public String getSubject() {
+    return subject;
   }
 
-  public void setRule(String rule) {
-    this.rule = rule;
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public void setBody(String body) {
+    this.body = body;
   }
 
   public String getReason() {
@@ -61,6 +82,14 @@ public class EmailNotification extends BaseEntity<Long> {
 
   public void setEmailStatus(String emailStatus) {
     this.emailStatus = emailStatus;
+  }
+
+  public Date getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Date timestamp) {
+    this.timestamp = timestamp;
   }
 
   public Date getTimestampSend() {

--- a/src/main/java/com/ciandt/techgallery/service/EmailService.java
+++ b/src/main/java/com/ciandt/techgallery/service/EmailService.java
@@ -8,6 +8,6 @@ public interface EmailService {
 
   void push(EmailConfig email);
 
-  void execute(String subject, String body, String reason, String to);
+  void execute(Long emailNotificationId);
 
 }

--- a/src/main/java/com/ciandt/techgallery/servlets/EmailServlet.java
+++ b/src/main/java/com/ciandt/techgallery/servlets/EmailServlet.java
@@ -14,7 +14,6 @@ public class EmailServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) {
-    emailService.execute(request.getParameter("subject"), request.getParameter("body"),
-        request.getParameter("reason"), request.getParameter("to"));
+    emailService.execute(Long.parseLong(request.getParameter("emailNotificationId")));
   }
 }


### PR DESCRIPTION
Fix exception `IllegalArgumentException: Task size too large`.

These exceptions appears at cron jobs when the payload is too large, and it occurs a lot since one of the arguments is a html email body.

The maximum task size is 100KB for push queues https://cloud.google.com/appengine/quotas#Task_Queue

We already had the EmailNotification Kind, and it is used to track when a email was sent (with success/failure status).

Changes in it:
- `rule` was removed since it isn't used and the value is null for all existing entities
- `subject` and `body` was added to receive the email information
- `timestamp` was added to track when the entity was created


Other changes were made in two points: `push` and `execute`
1. When pushing to queue, we copy the EmailConfig information into an EmailNotification entity and save it. Then, we pass just the ID as a parameter instead of all data.
2. Then, when executing the task, we just retrieve the information from Datastore and proceed.

